### PR TITLE
Add git tooling + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+**/__pycache__

--- a/patch-adapter/pyproject.toml
+++ b/patch-adapter/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+pythonpath = [
+  ".", "src"
+]

--- a/patch-adapter/src/git.py
+++ b/patch-adapter/src/git.py
@@ -46,7 +46,39 @@ def full_apply(patch_path: str, target_dir: str) -> tuple[bool, str]:
     correctly, otherwise it returns False with the stderr output.
     '''
     cmd = f"git am < {patch_path}"
-    out, err = execute_in_directory(cmd)
+    out, err = execute_in_directory(cmd, target_dir)
     if err is not None and len(err) > 0:
         return False, err
+    return True, out
+
+
+def reset_hard(commit: str, target_dir: str) -> tuple[bool, str]:
+    '''
+    Apply the patch. This function returns true if the patch is applied
+    correctly, otherwise it returns False with the stderr output.
+    '''
+    cmd = f"git reset --hard {commit}"
+    out, err = execute_in_directory(cmd, target_dir)
+    if err is not None and len(err) > 0:
+        return False, err
+    return True, out
+
+
+def init(target_dir: str) -> tuple[bool, str]:
+    '''
+    Apply the patch. This function returns true if the patch is applied
+    correctly, otherwise it returns False with the stderr output.
+    '''
+    cmd = "git init"
+    out, err = execute_in_directory(cmd, target_dir)
+    return True, out
+
+
+def remove_repo(target_dir: str) -> tuple[bool, str]:
+    '''
+    Apply the patch. This function returns true if the patch is applied
+    correctly, otherwise it returns False with the stderr output.
+    '''
+    cmd = "rm -rf .git"
+    out, err = execute_in_directory(cmd, target_dir)
     return True, out

--- a/patch-adapter/src/git.py
+++ b/patch-adapter/src/git.py
@@ -1,0 +1,52 @@
+import subprocess
+import os
+
+
+def execute_command(command: str) -> tuple[str, str]:
+    '''
+    Execute a command on the shell, retrieve stdout and stderr.
+    @param command: the command to be executed
+    @return: tuple with stdout, stderr
+    '''
+    out = subprocess.run(command.split(' '), stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    return out.stdout.decode(), out.stderr.decode()
+
+
+def execute_in_directory(cmd: str, target_dir: str) -> tuple[str, str]:
+    '''
+    Executes a command in a directory, then changing the workdir to the
+    original one.
+    @param cmd: the command
+    @param target_dir: the directory in which to execute the command
+    @return: tuple with stdout, stderr
+    '''
+    current_dir = os.getcwd()
+    os.chdir(target_dir)
+    out, err = execute_command(cmd)
+    os.chdir(current_dir)
+    return out, err
+
+
+def apply_check(patch_path: str, target_dir: str) -> tuple[bool, str]:
+    '''
+    Perform a git apply --check. If it works, the function returns True. Else,
+    this function returns False and the error message.
+    '''
+    cmd = f"git apply --check {patch_path}"
+    out, err = execute_in_directory(cmd, target_dir)
+    if err is not None and len(err) > 0:
+        return False, err
+    return True, out
+
+
+def full_apply(patch_path: str, target_dir: str) -> tuple[bool, str]:
+    '''
+    Apply the patch. This function returns true if the patch is applied
+    correctly, otherwise it returns False with the stderr output.
+    '''
+    cmd = f"git am < {patch_path}"
+    out, err = execute_in_directory(cmd)
+    if err is not None and len(err) > 0:
+        return False, err
+    return True, out

--- a/patch-adapter/tests/conftest.py
+++ b/patch-adapter/tests/conftest.py
@@ -1,15 +1,25 @@
 import pytest
 
-import git
+from git import Git
 
 
 @pytest.fixture(scope="session", autouse=True)
 def start_git_repo():
     print("FIXTURE: Starting git repo...")
-    git.remove_repo("tests/data")
-    git.init("tests/data")
-    latest_id, _ = git.execute_in_directory("git log -n 1 --pretty=format:\"%H\"", "tests/data")
+    git = Git("tests/data")
+    git.remove_repo()
+    git.init()
+    git.add(["*"])
+    git.fast_commit("First commit")
+    latest_id, _ = git.execute_command("git log -n 1 --pretty=format:\"%H\"")
     yield
     print("FIXTURE: Cleanup git repo")
-    git.reset_hard(latest_id, "tests/data")
-    git.remove_repo("tests/data")
+    git.stash()
+    git.restore_all()
+    git.reset_hard(latest_id)
+    git.remove_repo()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def git():
+    return Git("tests/data")

--- a/patch-adapter/tests/conftest.py
+++ b/patch-adapter/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+import git
+
+
+@pytest.fixture(scope="session", autouse=True)
+def start_git_repo():
+    print("FIXTURE: Starting git repo...")
+    git.execute_in_directory("rm -rf .git", "tests/data")
+    git.execute_in_directory("git init", "tests/data")
+    latest_id, _ = git.execute_in_directory("git log -n 1 --pretty=format:\"%H\"", "tests/data")
+    yield
+    print("FIXTURE: Cleanup git repo")
+    git.execute_in_directory(f"git reset --hard {latest_id}", "tests/data")
+    git.execute_in_directory("rm -rf .git", "tests/data")

--- a/patch-adapter/tests/conftest.py
+++ b/patch-adapter/tests/conftest.py
@@ -6,10 +6,10 @@ import git
 @pytest.fixture(scope="session", autouse=True)
 def start_git_repo():
     print("FIXTURE: Starting git repo...")
-    git.execute_in_directory("rm -rf .git", "tests/data")
-    git.execute_in_directory("git init", "tests/data")
+    git.remove_repo("tests/data")
+    git.init("tests/data")
     latest_id, _ = git.execute_in_directory("git log -n 1 --pretty=format:\"%H\"", "tests/data")
     yield
     print("FIXTURE: Cleanup git repo")
-    git.execute_in_directory(f"git reset --hard {latest_id}", "tests/data")
-    git.execute_in_directory("rm -rf .git", "tests/data")
+    git.reset_hard(latest_id, "tests/data")
+    git.remove_repo("tests/data")

--- a/patch-adapter/tests/data/0001-Test-patch.patch
+++ b/patch-adapter/tests/data/0001-Test-patch.patch
@@ -1,0 +1,27 @@
+From 60f0dddd406ea8c26dca9208efa48bd58b819043 Mon Sep 17 00:00:00 2001
+From: Andrea Calabrese <andrea1995.c@live.com>
+Date: Tue, 15 Apr 2025 13:26:52 +0200
+Subject: [PATCH] Test patch
+
+This patch adds "hello world"
+
+Signed-off-by: Andrea Calabrese <andrea.calabrese@amarulasolutions.com>
+---
+ simple.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/simple.c b/simple.c
+index 4e43f4b..7791fbb 100644
+--- a/simple.c
++++ b/simple.c
+@@ -1,3 +1,6 @@
+ #include <stdio.h>
+ 
+-int main() { return 0; }
++int main() {
++  printf("Hello world!\n");
++  return 0;
++}
+-- 
+2.43.0
+

--- a/patch-adapter/tests/data/0002-Complex-file-patch.patch
+++ b/patch-adapter/tests/data/0002-Complex-file-patch.patch
@@ -1,0 +1,27 @@
+From cf65680b4b1a08b4bc65995b9808e9f3eca44a3e Mon Sep 17 00:00:00 2001
+From: Andrea Calabrese <andrea1995.c@live.com>
+Date: Tue, 15 Apr 2025 16:27:04 +0200
+Subject: [PATCH 2/2] Complex file patch
+
+This should be inapplicable without human intervention
+
+Signed-off-by: Andrea Calabrese <andrea1995.c@live.com>
+---
+ multiple_possibilities.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/multiple_possibilities.c b/multiple_possibilities.c
+index a9f785c..5c007b7 100644
+--- a/multiple_possibilities.c
++++ b/multiple_possibilities.c
+@@ -6,6 +6,6 @@ int print_stuff() {
+ }
+ 
+ int main() {
+-  printf("Hello world1!");
++  printf("Hello world!");
+   return 0;
+ }
+-- 
+2.43.0
+

--- a/patch-adapter/tests/data/multiple_possibilities.c
+++ b/patch-adapter/tests/data/multiple_possibilities.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int print_stuff() {
+  printf("Hello world");
+  return 0;
+}
+
+int main() {
+  printf("Hello world!");
+  return 0;
+}

--- a/patch-adapter/tests/data/simple.c
+++ b/patch-adapter/tests/data/simple.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { return 0; }

--- a/patch-adapter/tests/test_git.py
+++ b/patch-adapter/tests/test_git.py
@@ -1,18 +1,26 @@
 import pytest
 
-import git
-
 
 class Test:
 
-    def test_execute_command(self):
+    def test_execute_command(self, git):
         res, out = git.execute_command("ls")
         assert len(out) < 1 and len(res) > 0, "Expected output with no errors"
 
-    def test_apply_check_simple(self):
-        res, out = git.apply_check("0001-Test-patch.patch", "tests/data")
+    def test_apply_check_simple(self, git):
+        res, out = git.apply_check("0001-Test-patch.patch")
         assert res is True, "A simple patch should work correctly"
 
-    def test_apply_check_complex(self):
-        res, out = git.apply_check("0002-Complex-file-patch.patch", "tests/data")
+    def test_apply_check_complex(self, git):
+        res, out = git.apply_check("0002-Complex-file-patch.patch")
+        assert res is False and len(out) > 0, "A complex patch should not work so easily"
+
+    def test_apply_simple(self, git):
+        res, out = git.apply("0001-Test-patch.patch")
+        assert res is True, "A simple patch should work correctly"
+        res, out = git.apply_R("0001-Test-patch.patch")
+        assert res is True
+
+    def test_apply_complex(self, git):
+        res, out = git.apply("0002-Complex-file-patch.patch")
         assert res is False and len(out) > 0, "A complex patch should not work so easily"

--- a/patch-adapter/tests/test_git.py
+++ b/patch-adapter/tests/test_git.py
@@ -1,0 +1,18 @@
+import pytest
+
+import git
+
+
+class Test:
+
+    def test_execute_command(self):
+        res, out = git.execute_command("ls")
+        assert len(out) < 1 and len(res) > 0, "Expected output with no errors"
+
+    def test_apply_check_simple(self):
+        res, out = git.apply_check("0001-Test-patch.patch", "tests/data")
+        assert res is True, "A simple patch should work correctly"
+
+    def test_apply_check_complex(self):
+        res, out = git.apply_check("0002-Complex-file-patch.patch", "tests/data")
+        assert res is False and len(out) > 0, "A complex patch should not work so easily"


### PR DESCRIPTION
Add Git class with the commands we need + its test suite.

The test suite should ensure that everything is still working. 
To run the tests, go to the patch-adapter directory and just run `pytest tests`

It is a little strange to perform tests on a git repository inside of a git repository, but it works nontheless. To avoid getting a dirty git repo, a new repo is created inside of the _tests/data_ directory every time tests are created (and of course, it is deleted in the end).


-------

The idea behind this is having a flow in which first we try to apply the patch -> then, if we can not apply it, we should be able to try to apply it in different code positions -> then, if everything fails, we could resort to an external tool to help us. This patch takes care of the first step: testing the appliability of the patch