### PR TITLE
mend: Improve variable handling

### DIFF
--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -2,26 +2,36 @@ MEND_LOG_LEVEL ?= "debug"
 
 HOSTTOOLS += "java"
 
-python () {
-    if not d.getVar("WS_USERKEY"):
-        bb.error("WS_USERKEY must be set in local.conf or image recipe.")
-        raise Exception("WS_USERKEY not set")
+python mend_check_warn_handler() {
+    # Only warn once
+    if getattr(bb.event, 'mend_warned', False):
+        return
 
-    if not d.getVar("WS_APIKEY"):
-        bb.error("WS_APIKEY must be set in local.conf or image recipe.")
-        raise Exception("WS_APIKEY not set")
+    missing_vars = []
+    if not e.data.getVar("WS_USERKEY"):
+        missing_vars.append("WS_USERKEY")
+    if not e.data.getVar("WS_APIKEY"):
+        missing_vars.append("WS_APIKEY")
+    if not e.data.getVar("WS_PRODUCTNAME"):
+        missing_vars.append("WS_PRODUCTNAME")
 
-    if not d.getVar("WS_PRODUCTNAME"):
-        bb.error("WS_PRODUCTNAME must be set in local.conf or image recipe.")
-        raise Exception("WS_PRODUCTNAME not set")
+    if missing_vars:
+        bb.warn(f"The following variables must be set in local.conf or a recipe for mend checking to function: {', '.join(missing_vars)}")
 
-    if not d.getVar("WS_PRODUCTTOKEN"):
-        bb.error("WS_PRODUCTTOKEN must be set in local.conf or image recipe.")
-        raise Exception("WS_PRODUCTTOKEN not set")
+    # Set flag to avoid repeating
+    setattr(bb.event, 'mend_warned', True)
 }
 
+addhandler mend_check_warn_handler
+mend_check_warn_handler[eventmask] = "bb.event.ParseStarted"
+
 do_mend_check() {
-    unified_agent_cmd="java -jar /builder/wss-unified-agent.jar -logLevel \"${MEND_LOG_LEVEL}\" -userKey \"${WS_USERKEY}\" -apiKey \"${WS_APIKEY}\" -c /builder/amarula.wss.config -d \"${S}\" -product \"${WS_PRODUCTNAME}\" -productToken \"${WS_PRODUCTTOKEN}\" -project \"${BPN}\""
+
+    if [ -z "${WS_USERKEY}" ] || [ -z "${WS_APIKEY}" ] || [ -z "${WS_PRODUCTNAME}" ]; then
+      exit 0
+    fi
+
+    unified_agent_cmd="java -jar /builder/wss-unified-agent.jar -logLevel \"${MEND_LOG_LEVEL}\" -userKey \"${WS_USERKEY}\" -apiKey \"${WS_APIKEY}\" -c /builder/amarula.wss.config -d \"${S}\" -product \"${WS_PRODUCTNAME}\" -project \"${BPN}\""
 
     echo "Executing Mend Unified Agent command: ${unified_agent_cmd}"
 


### PR DESCRIPTION
Avoid failing the build if variables required by mend checking are not set.
Instead, issue a single warning and don't execute the mend checking.

Additionally, remove dependency from the product token, as the product name is sufficient.