### PR TITLE
README: drop product token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ It requires the host's java runtime, for which a custom `kas-container` image is
     WS_APIKEY = "<apiKey>"
     WS_WSS_URL = "<wssUrl>"
     WS_PRODUCTNAME = "<productName>"
-    WS_PRODUCTTOKEN = "<productToken>"
 
 
 If using kas-container, `docker load` the docker image container found at:


### PR DESCRIPTION
Following the drop of the product token variable, which is not required when specifying the product name, remove it from the instructions in the README too.