### PR TITLE
Ignore patched CVEs and add report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It requires the host's java runtime, for which a custom `kas-container` image is
     WS_APIKEY = "<apiKey>"
     WS_WSS_URL = "<wssUrl>"
     WS_PRODUCTNAME = "<productName>"
+    WS_PRODUCTTOKEN = "<productToken>"
 
 
 If using kas-container, `docker load` the docker image container found at:

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -2,6 +2,23 @@ MEND_LOG_LEVEL ?= "debug"
 
 HOSTTOOLS += "java"
 
+def mend_request(encoded_data):
+    import urllib.request
+
+    response = ""
+    httprequest = urllib.request.Request(
+        method="POST",
+        url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
+        data=encoded_data,
+        headers={"Content-Type": "application/json"},
+    )
+
+    with urllib.request.urlopen(httprequest) as httpresponse:
+        response = httpresponse.read().decode() if httpresponse.status == 200 else ""
+
+    return response
+
+
 python mend_check_warn_handler() {
     # Only warn once
     if getattr(bb.event, 'mend_warned', False):
@@ -28,9 +45,6 @@ mend_check_warn_handler[eventmask] = "bb.event.ParseStarted"
 python do_mend_check() {
     from oe.cve_check import get_patched_cves
     import json
-    import urllib.request
-    import urllib.parse
-    import urllib.error
 
     if not d.getVar("WS_USERKEY") or not d.getVar("WS_APIKEY") or not d.getVar("WS_PRODUCTNAME"):
         return
@@ -50,17 +64,7 @@ python do_mend_check() {
                 }
             )
 
-            res = ""
-            httprequest = urllib.request.Request(
-                method="POST",
-                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
-                data=data.encode(),
-                headers={"Content-Type": "application/json"},
-            )
-
-            with urllib.request.urlopen(httprequest) as httpresponse:
-                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
-
+            res = mend_request(data.encode())
             if res == "":
                 raise Exception("HTTP Response error.")
 
@@ -81,17 +85,7 @@ python do_mend_check() {
                 }
             )
 
-            res = ""
-            httprequest = urllib.request.Request(
-                method="POST",
-                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
-                data=data.encode(),
-                headers={"Content-Type": "application/json"},
-            )
-
-            with urllib.request.urlopen(httprequest) as httpresponse:
-                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
-
+            res = mend_request(data.encode())
             if res == "":
                 raise Exception("HTTP Response error.")
 
@@ -112,17 +106,7 @@ python do_mend_check() {
                 }
             )
 
-            res = ""
-            httprequest = urllib.request.Request(
-                method="POST",
-                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
-                data=data.encode(),
-                headers={"Content-Type": "application/json"},
-            )
-
-            with urllib.request.urlopen(httprequest) as httpresponse:
-                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
-
+            res = mend_request(data.encode())
             if res == "":
                 raise Exception("HTTP Response error.")
 

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -25,19 +25,117 @@ python mend_check_warn_handler() {
 addhandler mend_check_warn_handler
 mend_check_warn_handler[eventmask] = "bb.event.ParseStarted"
 
-do_mend_check() {
+python do_mend_check() {
+    from oe.cve_check import get_patched_cves
+    import json
+    import urllib.request
+    import urllib.parse
+    import urllib.error
 
-    if [ -z "${WS_USERKEY}" ] || [ -z "${WS_APIKEY}" ] || [ -z "${WS_PRODUCTNAME}" ]; then
-      exit 0
-    fi
+    if not d.getVar("WS_USERKEY") or not d.getVar("WS_APIKEY") or not d.getVar("WS_PRODUCTNAME"):
+        return
 
-    unified_agent_cmd="java -jar /builder/wss-unified-agent.jar -logLevel \"${MEND_LOG_LEVEL}\" -userKey \"${WS_USERKEY}\" -apiKey \"${WS_APIKEY}\" -c /builder/amarula.wss.config -d \"${S}\" -product \"${WS_PRODUCTNAME}\" -project \"${BPN}\""
+    patched_cves = get_patched_cves(d)
 
-    echo "Executing Mend Unified Agent command: ${unified_agent_cmd}"
+    if patched_cves:
+        bb.note(f"Found {d.getVar('BPN')} patched cves: {patched_cves}")
 
-    eval "${unified_agent_cmd}"
+        try:
+            # GET PROJECT TOKEN FROM PACKAGE NAME
+            data = json.dumps(
+                {
+                    "requestType": "getAllProjects",
+                    "userKey": d.getVar('WS_USERKEY'),
+                    "productToken": d.getVar('WS_PRODUCTTOKEN')
+                }
+            )
 
-    echo "Mend Unified Agent scan completed."
+            res = ""
+            httprequest = urllib.request.Request(
+                method="POST",
+                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
+                data=data.encode(),
+                headers={"Content-Type": "application/json"},
+            )
+
+            with urllib.request.urlopen(httprequest) as httpresponse:
+                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
+
+            if res == "":
+                raise Exception("HTTP Response error.")
+
+            response_json = json.loads(res)
+            package_name = d.getVar('BPN')
+            project_token = ""
+            for project in response_json.get("projects", []):
+                if project.get("projectName") == package_name:
+                    project_token = project.get("projectToken")
+                    break
+
+            # GET VULNERABILITY UUIDs FROM CVE CODES
+            data = json.dumps(
+                {
+                    "requestType": "getProjectAlerts",
+                    "userKey": d.getVar('WS_USERKEY'),
+                    "projectToken": project_token
+                }
+            )
+
+            res = ""
+            httprequest = urllib.request.Request(
+                method="POST",
+                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
+                data=data.encode(),
+                headers={"Content-Type": "application/json"},
+            )
+
+            with urllib.request.urlopen(httprequest) as httpresponse:
+                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
+
+            if res == "":
+                raise Exception("HTTP Response error.")
+
+            response_json = json.loads(res)
+            alert_uuids = []
+            for alert in response_json.get("alerts", []):
+                if alert.get("vulnerability", {}).get("name") in patched_cves:
+                    alert_uuids.append(alert.get("alertUuid"))
+
+            # SET MEND TO IGNORE PATCHED VULNERABILITIES
+            data = json.dumps(
+                {
+                    "requestType": "ignoreAlerts",
+                    "orgToken": d.getVar('WS_APIKEY'),
+                    "userKey": d.getVar('WS_USERKEY'),
+                    "alertUuids": alert_uuids,
+                    "comments": "Automatically ignored by Mend utility",
+                }
+            )
+
+            res = ""
+            httprequest = urllib.request.Request(
+                method="POST",
+                url="https://saas-eu.whitesourcesoftware.com/api/v1.4",
+                data=data.encode(),
+                headers={"Content-Type": "application/json"},
+            )
+
+            with urllib.request.urlopen(httprequest) as httpresponse:
+                res = httpresponse.read().decode() if httpresponse.status == 200 else ""
+
+            if res == "":
+                raise Exception("HTTP Response error.")
+
+        except Exception as err:
+            bb.warn(f"Ignoring alerts process failed. Details: {err}")
+
+    unified_agent_cmd = f"java -jar /builder/wss-unified-agent.jar -logLevel \"{d.getVar('MEND_LOG_LEVEL')}\" -userKey \"{d.getVar('WS_USERKEY')}\" -apiKey \"{d.getVar('WS_APIKEY')}\" -c \"/builder/amarula.wss.config\" -d \"{d.getVar('S')}\" -product \"{d.getVar('WS_PRODUCTNAME')}\" -project \"{d.getVar('BPN')}\""
+
+    bb.note(f"Executing Mend Unified Agent command: {unified_agent_cmd}")
+
+    bb.process.run(unified_agent_cmd, shell=True)
+
+    bb.note("Mend Unified Agent scan completed.")
 }
 
 addtask mend_check after do_patch before do_build


### PR DESCRIPTION
Currently, the mend scan is launched without taking into account the
CVEs that are patched by the Yocto Project.
This leads to the report containing vulnerabilities which are not
actually present in the project.

Fix this by taking the patched CVEs and using the Mend API to set the
vulnerability alerts caused by them to be ignored.

Additionally, as a final json report with all of the project's vulnerabilities is
often necessary, add its generation at the end of the entire build
process, similarly to what is being done with CVE.