### PR TITLE
Remove Java dependency, add PDF report generation and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,44 @@ A Layer to support Mend SCA (Software Composition Analysis) for open-source vuln
 ## usage
 
 This layer exposes a bbclass to apply mend checking.
-It requires the host's java runtime, for which a custom `kas-container` image is provided, which also includes Java.
+It uses the `mend-cli` standalone tool provided by Mend.
+To automatically authenticate the `mend-cli` tool and allow it to
+access your organisation, some environment variables must be
+exported:
+
+    MEND_URL
+    MEND_USER_KEY
+    MEND_EMAIL
+
+For this project, the variables are exported directly from the
+`.bbclass`, so it is sufficient to add them as follows:
 
  ### In conf/local.conf (or in the local_conf_header section of the kas configuration):
+
+```
     INHERIT += " mend"
     
     WS_USERKEY = "<userKey>"
     WS_APIKEY = "<apiKey>"
-    WS_WSS_URL = "<wssUrl>"
     WS_PRODUCTNAME = "<productName>"
     WS_PRODUCTTOKEN = "<productToken>"
+    MEND_URL = "<mendUrl>"
+    MEND_EMAIL = "<email>"
+```
 
-
-If using kas-container, `docker load` the docker image container found at:
-https://drive.google.com/file/d/1gMtveXMFtlW_pdADBy5-ARqEu4dgyN7p
-then prepend the following to the command when using kas-container:
-    KAS_CONTAINER_IMAGE=amarula/kas-java:latest kas-container [...]
-
-Alternative you can use docker-compose. Adjust your docker registry to
-your specific one and KAS_CONTAINER_IMAGE to the right one.
-
-    cd docker
-    docker compose build
+- `INHERIT += " mend"` is similar to what is done for _cve_ checking,
+  and makes it so that all recipes globally inherit the _.bbclass_ and
+  the entire Yocto project is checked.
+- `WS_USERKEY` and `WS_APIKEY` are personal and can be found from the
+  Mend web interface for your organization.
+- `WS_PRODUCTNAME` is your desired product name: if a product with that
+  name is already present, it will be updated; if it doesn't exist, its
+  creation will be automatically handled by _meta-mend_.
+- `MEND_URL` is the Mend environment URL of your shared instance.
+  More information about this and the list of supported values
+  can be found at this
+  [link](https://docs.mend.io/platform/latest/authenticate-your-login-for-the-mend-cli#AuthenticateyourloginfortheMendCLI-MendCLI-mendauthloginparameters).
+- `MEND_EMAIL` must be set to the email of the account
+  corresponding to the `WS_USERKEY`.
+- Note that `MEND_USER_KEY` is not required, as it is the same as
+  `WS_USERKEY` and this is handled internally.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ For this project, the variables are exported directly from the
     WS_USERKEY = "<userKey>"
     WS_APIKEY = "<apiKey>"
     WS_PRODUCTNAME = "<productName>"
-    WS_PRODUCTTOKEN = "<productToken>"
     MEND_URL = "<mendUrl>"
     MEND_EMAIL = "<email>"
 ```

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -3,7 +3,7 @@ MEND_CHECK_SUMMARY_DIR ?= "${LOG_DIR}/mend/"
 
 HOSTTOOLS += "java"
 
-WS_AGENT_CONFIG ??= "/repo/meta-mend/files/mend.wss.config"
+WS_AGENT_CONFIG ??= "/work/meta-mend/files/mend.wss.config"
 
 def mend_request(encoded_data):
     import urllib.request

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -1,6 +1,7 @@
 MEND_VERSION = "25.7.1"
-MEND_LOG_LEVEL ?= "debug"
 MEND_CHECK_SUMMARY_DIR ?= "${LOG_DIR}/mend/"
+MEND_LOG_LEVEL ?= "DEBUG"
+export MEND_LOG_LEVEL
 
 WS_AGENT_CONFIG ??= "/work/meta-mend/files/mend.wss.config"
 

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -28,13 +28,13 @@ python mend_check_warn_handler() {
         return
 
     missing_vars = []
-    if not e.data.getVar("WS_USERKEY"):
+    if not d.getVar("WS_USERKEY"):
         missing_vars.append("WS_USERKEY")
-    if not e.data.getVar("WS_APIKEY"):
+    if not d.getVar("WS_APIKEY"):
         missing_vars.append("WS_APIKEY")
-    if not e.data.getVar("WS_PRODUCTNAME"):
+    if not d.getVar("WS_PRODUCTNAME"):
         missing_vars.append("WS_PRODUCTNAME")
-    if not e.data.getVar("WS_PRODUCTTOKEN"):
+    if not d.getVar("WS_PRODUCTTOKEN"):
         missing_vars.append("WS_PRODUCTTOKEN")
 
     if missing_vars:

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -179,7 +179,7 @@ python do_mend_check() {
 
     bb.note(f"Executing Mend Unified Agent command: {unified_agent_cmd}")
 
-    bb.process.run(unified_agent_cmd, shell=True)
+    bb.process.run(unified_agent_cmd)
 
     bb.note("Mend Unified Agent scan completed.")
 }


### PR DESCRIPTION
Using the Mend Unified Agent jar forces us to rely on a custom
kas-container with Java installed, and to use HOSTTOOLS to avoid
dependency loops.

Both of these things are less than ideal.

To address this, introduce the self-contained `mend-cli` binary in the
meta layer's files, which is then directly accessed by kas-container.
This binary allows us to use the Mend Unified Agent WITHOUT having the
Java JRE and SDK installed, which means it is possible to use the
regular kas-container.
Additionally, since it is provided directly as a binary by Mend, it does
not require compilation and helps to avoid dependency loops.

Add the necessary environment variables to authenticate the mend-cli
tool, and move the mend_unified_agent command from using the jar to the
new tool.

Together with this, some small fixes which should not change
the behaviour.