### PR TITLE
classes: mend.bbclass: Skip recipt from blacklist package

### DIFF
--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -237,6 +237,13 @@ python do_mend_check() {
     if not d.getVar("WS_USERKEY") or not d.getVar("WS_APIKEY") or not d.getVar("WS_PRODUCTNAME") or not d.getVar("MEND_URL"):
         return
 
+    blacklist_str = d.getVar("MEND_BLACKLIST_PACKAGE") or ""
+    blacklist = blacklist_str.split()
+    pn = d.getVar("PN")
+    if pn in blacklist:
+        bb.note("Mend scan skipped: '%s' is in MEND_BLACKLIST_PACKAGE" % pn)
+        return
+
     # Don't run package scan on native package
     if not d.getVar('CLASSOVERRIDE') == 'class-target':
         return

--- a/classes/mend.bbclass
+++ b/classes/mend.bbclass
@@ -241,6 +241,9 @@ python do_mend_check() {
     if not d.getVar('CLASSOVERRIDE') == 'class-target':
         return
 
+    if bb.data.inherits_class("nopackages", d):
+        return
+
     # Don't run scan on packages with closed license
     if d.getVar('LICENSE') == 'CLOSED':
         return


### PR DESCRIPTION
If the nopackage class is inherit, we can skip it because it will not provide any file in rootfs to be considered in the scan.

Example gcc-initial