### PR TITLE
README.md: Update documentation for pdf report format change

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,7 @@ configuration:
 The report can then be found at:
 
 ```
-build/tmp-glibc/log/mend/mend-report-YYYYMMDDhhmmss.pdf
+build/tmp-glibc/log/mend/mend-report-YYYYMMDDhhmmss.zip
 ```
+
+The file is a zipped version that contains the pdf reporting


### PR DESCRIPTION
The pdf now is inside a zip file. A zip is used when the report is very large and we need to split it up in multiple files.